### PR TITLE
 Update lamp manifest.yaml

### DIFF
--- a/stack/lamp/manifest.yaml
+++ b/stack/lamp/manifest.yaml
@@ -7,7 +7,7 @@ type: stack
 description: LAMP is an acronym for the operating system, Linux; the web server, Apache; the database server, MariaDB; and the programming language, PHP. All four of these technologies are open source, which means they are community maintained and freely available for anyone to use. Developers use LAMP stacks to create, host, and maintain web content. It is a popular solution that powers many of the websites you commonly use today.
 services:
   - php:8.3
-  - mariadb:11:4
+  - mariadb:11.4
 mappings:
   - path: /
     matchPattern: begins-with

--- a/stack/lamp/manifest.yaml
+++ b/stack/lamp/manifest.yaml
@@ -6,7 +6,7 @@ name: LAMP
 type: stack
 description: LAMP is an acronym for the operating system, Linux; the web server, Apache; the database server, MariaDB; and the programming language, PHP. All four of these technologies are open source, which means they are community maintained and freely available for anyone to use. Developers use LAMP stacks to create, host, and maintain web content. It is a popular solution that powers many of the websites you commonly use today.
 services:
-  - php:8.3
+  - php-webserver
   - mariadb:11.4
 mappings:
   - path: /

--- a/stack/lamp/manifest.yaml
+++ b/stack/lamp/manifest.yaml
@@ -4,10 +4,10 @@ slugs:
   - lemp
 name: LAMP
 type: stack
-description: LAMP is an acronym for the operating system, Linux; the web server, Apache; the database server, MySQL; and the programming language, PHP. All four of these technologies are open source, which means they are community maintained and freely available for anyone to use. Developers use LAMP stacks to create, host, and maintain web content. It is a popular solution that powers many of the websites you commonly use today.
+description: LAMP is an acronym for the operating system, Linux; the web server, Apache; the database server, MariaDB; and the programming language, PHP. All four of these technologies are open source, which means they are community maintained and freely available for anyone to use. Developers use LAMP stacks to create, host, and maintain web content. It is a popular solution that powers many of the websites you commonly use today.
 services:
-  - php
-  - mysql
+  - php:8.3
+  - mariadb:11:4
 mappings:
   - path: /
     matchPattern: begins-with


### PR DESCRIPTION
Defined the latest supported versions of PHP and MariaDB. Replaced the MySQL service with MariaDB, since MySQL did not yet exist Manifest.

Without specifying the PHP version, install 7.4, while the MySQL service that was previously installed installs the latest MariaDB.