### PR TITLE
fix: set webhook url on n8n

### DIFF
--- a/app/n8n/assets/env.txt
+++ b/app/n8n/assets/env.txt
@@ -3,7 +3,9 @@ GENERIC_TIMEZONE = "America/New_York"
 N8N_RELEASE_TYPE = "stable"
 N8N_DEFAULT_LOCALE = "en"
 
-N8N_EDITOR_BASE_URL = "https://n8n_editor_base_url"
+N8N_EDITOR_BASE_URL = "https://n8n_base_url"
+WEBHOOK_URL = "https://n8n_base_url"
+
 N8N_USER_FOLDER = "n8n_user_folder"
 
 N8N_HIDE_USAGE_PAGE = true

--- a/app/n8n/manifest.yml
+++ b/app/n8n/manifest.yml
@@ -8,7 +8,7 @@ description: n8n is a workflow automation platform that gives technical teams th
 installCmdSteps:
   - install_packages -qq jq
   - cp -u %marketplaceCatalogItemAssetsDirPath%/env.txt %installDirectory%/.env
-  - sed -i 's|n8n_editor_base_url|%installHostname%|' %installDirectory%/.env
+  - sed -i 's|n8n_base_url|%installHostname%|' %installDirectory%/.env
   - sed -i 's|n8n_user_folder|%installDirectory%|' %installDirectory%/.env
   - cd %installDirectory% && mise x node@20 -- npm install n8n@latest
   - os services create-installable --name node --port-bindings 5678/ws --version 20 --auto-create-mapping true --auto-start true --auto-restart true --startup-file %installDirectory%/node_modules/.bin/n8n --working-dir %installDirectory%

--- a/app/n8n/manifest.yml
+++ b/app/n8n/manifest.yml
@@ -8,7 +8,7 @@ description: n8n is a workflow automation platform that gives technical teams th
 installCmdSteps:
   - install_packages -qq jq
   - cp -u %marketplaceCatalogItemAssetsDirPath%/env.txt %installDirectory%/.env
-  - sed -i 's|n8n_base_url|%installHostname%|' %installDirectory%/.env
+  - sed -i 's|n8n_base_url|%installHostname%|g' %installDirectory%/.env
   - sed -i 's|n8n_user_folder|%installDirectory%|' %installDirectory%/.env
   - cd %installDirectory% && mise x node@20 -- npm install n8n@latest
   - os services create-installable --name node --port-bindings 5678/ws --version 20 --auto-create-mapping true --auto-start true --auto-restart true --startup-file %installDirectory%/node_modules/.bin/n8n --working-dir %installDirectory%


### PR DESCRIPTION
This pull request updates the configuration and installation process for the `n8n` workflow automation platform. The most important changes include modifying environment variable names for consistency and updating the installation script to reflect these changes.

### Configuration Updates:
* [`app/n8n/assets/env.txt`](diffhunk://#diff-811fee6b63661f827d4bfd133411ceb3255fba27eb2ef906e6a7c443fbca3aeeL6-R8): Renamed `n8n_editor_base_url` to `n8n_base_url` placeholder and added a new `WEBHOOK_URL` variable to improve clarity and functionality.

### Installation Script Updates:
* [`app/n8n/manifest.yml`](diffhunk://#diff-948733f55c432fc41cf7e647ae85ec51bb696afe7949c2800fa69a8e1308ce80L11-R11): Updated the `sed` command in the installation script to replace the new `n8n_base_url` variable instead of the old `n8n_editor_base_url`. This ensures compatibility with the updated environment variable naming convention.