### PR TITLE
fix: moodle must use `nobody` user on install and cron

### DIFF
--- a/app/moodle/manifest.yml
+++ b/app/moodle/manifest.yml
@@ -43,17 +43,15 @@ installCmdSteps:
   - wget -q https://download.moodle.org/download.php/direct/stable405/moodle-latest-405.tgz -O %installTempDir%/moodle.tgz
   - cd %installTempDir% && tar -xzf moodle.tgz
   - shopt -s dotglob && mv %installTempDir%/moodle/* %installDirectory% && shopt -u dotglob
-  - mkdir /app/%installHostname%-moodledata
   - os runtime php update --hostname %installHostname% --version 8.3
   - os runtime php update-setting --hostname %installHostname% --version 8.3 --name max_input_vars --value 7200
   - sed -i 's/uca1400_ai_ci/general_ci/' /etc/mysql/mariadb.conf.d/50-server.cnf
   - os services update --name mariadb --status restart
   - os db create --db-type mysql --db-name moodle_%installUuid%
   - os db create-user --db-type mysql --db-name moodle_%installUuid% --username moodle_%installUuid% --password '%installRandomPassword%' --privileges all
-  - php -d max_input_vars=5000 %installDirectory%/admin/cli/install.php --chmod=755 --wwwroot='https://%installHostname%%installUrlPath%' --dataroot='/app/%installHostname%-moodledata' --dbtype=mariadb --dbname=moodle_%installUuid% --dbuser=moodle_%installUuid% --dbpass='%installRandomPassword%' --dbport=3306 --fullname='%siteFullName%' --shortname='%siteShortName%' --adminuser='%adminUsername%' --adminpass='%adminPassword%' --adminemail='%adminEmail%' --non-interactive --agree-license
+  - su nobody --shell /bin/bash -c "php -d max_input_vars=5000 %installDirectory%/admin/cli/install.php --chmod=755 --wwwroot='https://%installHostname%%installUrlPath%' --dataroot='/app/%installHostname%-moodledata' --dbtype=mariadb --dbname=moodle_%installUuid% --dbuser=moodle_%installUuid% --dbpass='%installRandomPassword%' --dbport=3306 --fullname='%siteFullName%' --shortname='%siteShortName%' --adminuser='%adminUsername%' --adminpass='%adminPassword%' --adminemail='%adminEmail%' --non-interactive --agree-license"
   - echo -e '\n$CFG->routerconfigured = true;\n' >>%installDirectory%/config.php
-  - os cron create -s '* * * * *' -d 'MoodleCron' -c 'php %installDirectory%/admin/cli/cron.php'
-  - sleep 120 && chown -Rc nobody:nogroup /app/%installHostname%-moodledata/
+  - os cron create --schedule '* * * * *' --comment 'MoodleCron' --command 'su nobody --shell /bin/bash -c "php %installDirectory%/admin/cli/cron.php"'
 uninstallCmdSteps:
   - mkdir -p /app/.trash/moodle-%installHostname%-%installUuid%
   - shopt -s dotglob && mv %installDirectory%/* /app/%installHostname%-moodledata/ /app/.trash/moodle-%installHostname%-%installUuid%/ && shopt -u dotglob


### PR DESCRIPTION
This pull request updates the `installCmdSteps` section in the `app/moodle/manifest.yml` file to enhance security and improve command consistency. The most significant changes include replacing direct command executions with the `su` command to run as the `nobody` user, and modifying the `os cron create` syntax for better clarity.

### Security Enhancements:
* Replaced the direct execution of the Moodle installation script with a command that runs as the `nobody` user using `su`, improving security by avoiding execution as a privileged user. (`[app/moodle/manifest.ymlL46-R54](diffhunk://#diff-db619e9875cf9d90767c7925fe2e6f2259df91757a42d0fa3000308d4ac0581dL46-R54)`)
* Updated the `os cron create` command to execute the Moodle cron job as the `nobody` user via `su`, ensuring the cron job runs with minimal privileges. (`[app/moodle/manifest.ymlL46-R54](diffhunk://#diff-db619e9875cf9d90767c7925fe2e6f2259df91757a42d0fa3000308d4ac0581dL46-R54)`)

### Command Consistency:
* Refactored the `os cron create` command to use more descriptive flags (`--schedule`, `--comment`, `--command`) for improved readability and maintainability. (`[app/moodle/manifest.ymlL46-R54](diffhunk://#diff-db619e9875cf9d90767c7925fe2e6f2259df91757a42d0fa3000308d4ac0581dL46-R54)`)