### PR TITLE
fix: n8n manifest subdomain mapping

### DIFF
--- a/app/n8n/manifest.yml
+++ b/app/n8n/manifest.yml
@@ -5,13 +5,18 @@ slugs:
 name: n8n
 type: app
 description: n8n is a workflow automation platform that gives technical teams the flexibility of code with the speed of no-code. With 400+ integrations, native AI capabilities, and a fair-code license, n8n lets you build powerful automations while maintaining full control over your data and deployments.
+mappings:
+  - path: /
+    matchPattern: begins-with
+    targetType: service
+    targetValue: node
 installCmdSteps:
   - install_packages -qq jq
   - cp -u %marketplaceCatalogItemAssetsDirPath%/env.txt %installDirectory%/.env
   - sed -i 's|n8n_base_url|%installHostname%|g' %installDirectory%/.env
   - sed -i 's|n8n_user_folder|%installDirectory%|' %installDirectory%/.env
   - cd %installDirectory% && mise x node@20 -- npm install n8n@latest
-  - os services create-installable --name node --port-bindings 5678/ws --version 20 --auto-create-mapping true --auto-start true --auto-restart true --startup-file %installDirectory%/node_modules/.bin/n8n --working-dir %installDirectory%
+  - os services create-installable --name node --port-bindings 5678/ws --version 20 --auto-create-mapping false --auto-start true --auto-restart true --startup-file %installDirectory%/node_modules/.bin/n8n --working-dir %installDirectory%
 uninstallCmdSteps:
   - cd %installDirectory% && mise x node@20 -- npm uninstall n8n
   - mv %installDirectory%/.n8n /app/.trash/.n8n-$(date +%s)


### PR DESCRIPTION
This pull request updates the `n8n` application manifest to improve service mapping configuration and refine service creation behavior. The most important changes include adding a new `mappings` section and modifying the `os services create-installable` command.

### Updates to service mapping and creation:

* **Added `mappings` section**: Introduced a new `mappings` section to define a path-based mapping for the service, specifying a `matchPattern` of `begins-with`, a `targetType` of `service`, and a `targetValue` of `node`. This enhances the flexibility of service routing. (`[app/n8n/manifest.ymlR8-R19](diffhunk://#diff-948733f55c432fc41cf7e647ae85ec51bb696afe7949c2800fa69a8e1308ce80R8-R19)`)

* **Modified service creation command**: Changed the `os services create-installable` command to set `auto-create-mapping` to `false`, providing finer control over mapping creation during service installation. (`[app/n8n/manifest.ymlR8-R19](diffhunk://#diff-948733f55c432fc41cf7e647ae85ec51bb696afe7949c2800fa69a8e1308ce80R8-R19)`)