### PR TITLE
Fix images path

### DIFF
--- a/app/adobeCommerce/manifest.yml
+++ b/app/adobeCommerce/manifest.yml
@@ -834,8 +834,8 @@ uninstallFileNames:
   - "*.sample"
   - composer*
 estimatedSizeBytes: 779091968
-avatarUrl: "https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/adobeCommerce/assets/avatar.jpg"
+avatarUrl: "https://goinfinite.github.io/os-marketplace/app/adobeCommerce/assets/avatar.jpg"
 screenshotUrls:
-  - "https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/adobeCommerce/assets/screenshot-1.jpg"
-  - "https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/adobeCommerce/assets/screenshot-2.jpg"
-  - "https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/adobeCommerce/assets/screenshot-3.jpg"
+  - "https://goinfinite.github.io/os-marketplace/app/adobeCommerce/assets/screenshot-1.jpg"
+  - "https://goinfinite.github.io/os-marketplace/app/adobeCommerce/assets/screenshot-2.jpg"
+  - "https://goinfinite.github.io/os-marketplace/app/adobeCommerce/assets/screenshot-3.jpg"

--- a/app/drupal/manifest.json
+++ b/app/drupal/manifest.json
@@ -79,11 +79,11 @@
     "web.config"
   ],
   "estimatedSizeBytes": 100000000,
-  "avatarUrl": "https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/drupal/assets/avatar.jpg",
+  "avatarUrl": "https://goinfinite.github.io/os-marketplace/app/drupal/assets/avatar.jpg",
   "screenshotUrls": [
-    "https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/drupal/assets/screenshot-1.jpg",
-    "https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/drupal/assets/screenshot-2.jpg",
-    "https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/drupal/assets/screenshot-3.jpg",
-    "https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/drupal/assets/screenshot-4.jpg"
+    "https://goinfinite.github.io/os-marketplace/app/drupal/assets/screenshot-1.jpg",
+    "https://goinfinite.github.io/os-marketplace/app/drupal/assets/screenshot-2.jpg",
+    "https://goinfinite.github.io/os-marketplace/app/drupal/assets/screenshot-3.jpg",
+    "https://goinfinite.github.io/os-marketplace/app/drupal/assets/screenshot-4.jpg"
   ]
 }

--- a/app/joomla/manifest.json
+++ b/app/joomla/manifest.json
@@ -77,10 +77,10 @@
     "robots.txt"
   ],
   "estimatedSizeBytes": 100000000,
-  "avatarUrl": "https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/joomla/assets/avatar.jpg",
+  "avatarUrl": "https://goinfinite.github.io/os-marketplace/app/joomla/assets/avatar.jpg",
   "screenshotUrls": [
-    "https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/joomla/assets/screenshot-1.jpg",
-    "https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/joomla/assets/screenshot-2.jpg",
-    "https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/joomla/assets/screenshot-3.jpg"
+    "https://goinfinite.github.io/os-marketplace/app/joomla/assets/screenshot-1.jpg",
+    "https://goinfinite.github.io/os-marketplace/app/joomla/assets/screenshot-2.jpg",
+    "https://goinfinite.github.io/os-marketplace/app/joomla/assets/screenshot-3.jpg"
   ]
 }

--- a/app/moodle/manifest.yml
+++ b/app/moodle/manifest.yml
@@ -60,8 +60,8 @@ uninstallCmdSteps:
   - os cron delete -d 'MoodleCron'
 installTimeoutSecs: 900
 estimatedSizeBytes: 372349285
-avatarUrl: https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/moodle/assets/avatar.png
+avatarUrl: https://goinfinite.github.io/os-marketplace/app/moodle/assets/avatar.png
 screenshotUrls:
-  - https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/moodle/assets/screenshot-1.png
-  - https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/moodle/assets/screenshot-2.png
-  - https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/moodle/assets/screenshot-3.png
+  - https://goinfinite.github.io/os-marketplace/app/moodle/assets/screenshot-1.png
+  - https://goinfinite.github.io/os-marketplace/app/moodle/assets/screenshot-2.png
+  - https://goinfinite.github.io/os-marketplace/app/moodle/assets/screenshot-3.png

--- a/app/n8n/manifest.yml
+++ b/app/n8n/manifest.yml
@@ -31,8 +31,8 @@ uninstallFileNames:
   - package-lock.json
 installTimeoutSecs: 900
 estimatedSizeBytes: 828403472
-avatarUrl: https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/n8n/assets/avatar.jpg
+avatarUrl: https://goinfinite.github.io/os-marketplace/app/n8n/assets/avatar.jpg
 screenshotUrls:
-  - https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/n8n/assets/screenshot-1.jpg
-  - https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/n8n/assets/screenshot-2.jpg
-  - https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/n8n/assets/screenshot-3.jpg
+  - https://goinfinite.github.io/os-marketplace/app/n8n/assets/screenshot-1.jpg
+  - https://goinfinite.github.io/os-marketplace/app/n8n/assets/screenshot-2.jpg
+  - https://goinfinite.github.io/os-marketplace/app/n8n/assets/screenshot-3.jpg

--- a/app/opencart/manifest.yml
+++ b/app/opencart/manifest.yml
@@ -58,7 +58,7 @@ uninstallFileNames:
   - php.ini
   - robots.txt
 estimatedSizeBytes: 100000000
-avatarUrl: "https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/opencart/assets/avatar.jpg"
+avatarUrl: "https://goinfinite.github.io/os-marketplace/app/opencart/assets/avatar.jpg"
 screenshotUrls:
-  - "https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/opencart/assets/screenshot-1.jpg"
-  - "https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/opencart/assets/screenshot-2.jpg"
+  - "https://goinfinite.github.io/os-marketplace/app/opencart/assets/screenshot-1.jpg"
+  - "https://goinfinite.github.io/os-marketplace/app/opencart/assets/screenshot-2.jpg"

--- a/app/openmage/manifest.json
+++ b/app/openmage/manifest.json
@@ -827,10 +827,10 @@
     "*.sample"
   ],
   "estimatedSizeBytes": 268435456,
-  "avatarUrl": "https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/openmage/assets/avatar.jpg",
+  "avatarUrl": "https://goinfinite.github.io/os-marketplace/app/openmage/assets/avatar.jpg",
   "screenshotUrls": [
-    "https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/openmage/assets/screenshot-1.jpg",
-    "https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/openmage/assets/screenshot-2.jpg",
-    "https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/openmage/assets/screenshot-3.jpg"
+    "https://goinfinite.github.io/os-marketplace/app/openmage/assets/screenshot-1.jpg",
+    "https://goinfinite.github.io/os-marketplace/app/openmage/assets/screenshot-2.jpg",
+    "https://goinfinite.github.io/os-marketplace/app/openmage/assets/screenshot-3.jpg"
   ]
 }

--- a/app/wordpress/manifest.json
+++ b/app/wordpress/manifest.json
@@ -75,12 +75,12 @@
     "xmlrpc.php"
   ],
   "estimatedSizeBytes": 100000000,
-  "avatarUrl": "https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/wordpress/assets/avatar.jpg",
+  "avatarUrl": "https://goinfinite.github.io/os-marketplace/app/wordpress/assets/avatar.jpg",
   "screenshotUrls": [
-    "https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/wordpress/assets/screenshot-1.jpg",
-    "https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/wordpress/assets/screenshot-2.jpg",
-    "https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/wordpress/assets/screenshot-3.jpg",
-    "https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/wordpress/assets/screenshot-4.jpg",
-    "https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/app/wordpress/assets/screenshot-5.jpg"
+    "https://goinfinite.github.io/os-marketplace/app/wordpress/assets/screenshot-1.jpg",
+    "https://goinfinite.github.io/os-marketplace/app/wordpress/assets/screenshot-2.jpg",
+    "https://goinfinite.github.io/os-marketplace/app/wordpress/assets/screenshot-3.jpg",
+    "https://goinfinite.github.io/os-marketplace/app/wordpress/assets/screenshot-4.jpg",
+    "https://goinfinite.github.io/os-marketplace/app/wordpress/assets/screenshot-5.jpg"
   ]
 }

--- a/framework/laravel/manifest.yaml
+++ b/framework/laravel/manifest.yaml
@@ -39,4 +39,4 @@ uninstallFileNames:
   - index.php
   - robots.txt
 estimatedSizeBytes: 55000000
-avatarUrl: https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/framework/laravel/assets/avatar.jpg
+avatarUrl: https://goinfinite.github.io/os-marketplace/framework/laravel/assets/avatar.jpg

--- a/stack/lamp/manifest.yaml
+++ b/stack/lamp/manifest.yaml
@@ -14,4 +14,4 @@ mappings:
     targetType: service
     targetValue: php
 estimatedSizeBytes: 2000000000
-avatarUrl: https://raw.githubusercontent.com/goinfinite/os-marketplace/refs/heads/v1/stack/lamp/assets/avatar.jpg
+avatarUrl: https://goinfinite.github.io/os-marketplace/stack/lamp/assets/avatar.jpg


### PR DESCRIPTION
This pull request updates the URLs for avatar images and screenshots across multiple application manifest files to use the `goinfinite.github.io` domain instead of `raw.githubusercontent.com`. This change ensures a more consistent and reliable hosting source for these assets.