### PR TITLE
chore: update manifests ids

### DIFF
--- a/app/adminer/manifest.yml
+++ b/app/adminer/manifest.yml
@@ -1,4 +1,5 @@
 manifestVersion: v1
+id: 13
 slugs:
   - adminer
 name: Adminer

--- a/app/adobeCommerce/manifest.yml
+++ b/app/adobeCommerce/manifest.yml
@@ -1,4 +1,5 @@
 manifestVersion: v1
+id: 6
 slugs:
   - adobeCommerce
   - adobe-commerce

--- a/app/drupal/manifest.json
+++ b/app/drupal/manifest.json
@@ -1,5 +1,6 @@
 {
   "manifestVersion": "v1",
+  "id": 11,
   "slugs": ["drupal"],
   "name": "Drupal",
   "type": "app",

--- a/app/joomla/manifest.json
+++ b/app/joomla/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifestVersion": "v1",
-  "id": 3,
+  "id": 12,
   "slugs": ["joomla"],
   "name": "Joomla",
   "type": "app",

--- a/app/mautic/manifest.yml
+++ b/app/mautic/manifest.yml
@@ -1,4 +1,5 @@
 manifestVersion: v1
+id: 7
 slugs:
   - mautic
 name: Mautic

--- a/app/moodle/manifest.yml
+++ b/app/moodle/manifest.yml
@@ -1,4 +1,5 @@
 manifestVersion: v1
+id: 8
 slugs:
   - moodle
 name: Moodle

--- a/app/n8n/manifest.yml
+++ b/app/n8n/manifest.yml
@@ -1,4 +1,5 @@
 manifestVersion: v1
+id: 3
 slugs:
   - n8n
   - n8n-io

--- a/app/openmage/manifest.json
+++ b/app/openmage/manifest.json
@@ -1,5 +1,6 @@
 {
   "manifestVersion": "v1",
+  "id": 5,
   "slugs": ["openmage", "magento1"],
   "name": "OpenMage",
   "type": "app",

--- a/app/passbolt/manifest.yml
+++ b/app/passbolt/manifest.yml
@@ -1,4 +1,5 @@
 manifestVersion: v1
+id: 9
 slugs:
   - passbolt
 name: Passbolt

--- a/app/phpmyadmin/manifest.yml
+++ b/app/phpmyadmin/manifest.yml
@@ -1,4 +1,5 @@
 manifestVersion: v1
+id: 4
 slugs:
   - phpmyadmin
   - phpMyAdmin

--- a/app/uptime-kuma/manifest.yml
+++ b/app/uptime-kuma/manifest.yml
@@ -1,4 +1,5 @@
 manifestVersion: v1
+id: 10
 slugs:
   - kuma
   - uptime-kuma


### PR DESCRIPTION
This pull request adds a unique `id` field to the manifest files for several app integrations, ensuring that each app has a distinct identifier for easier management and referencing. Additionally, the `id` value for the Joomla app was updated to avoid a conflict.

App manifest updates:

* Added an `id` field to the manifest files for the following apps: `adminer`, `adobeCommerce`, `drupal`, `mautic`, `moodle`, `n8n`, `openmage`, `passbolt`, `phpmyadmin`, and `uptime-kuma`. [[1]](diffhunk://#diff-f048ab3b756e4b6d9a1cfc48406378e07f867dce0e381fb710f801f04cebd4ecR2) [[2]](diffhunk://#diff-c7876adbf96973ad67c21e7d96daa5d64696cfb0b44d840f57da271266ee5b15R2) [[3]](diffhunk://#diff-eb31dbfd0cbcb2565203b2eecaf27c6cc0d81b2825d70782332811288723cdbfR3) [[4]](diffhunk://#diff-57927d5651fda0d4845254d070d6646feb27ba532f0bf99f8228af76a442211aR2) [[5]](diffhunk://#diff-db619e9875cf9d90767c7925fe2e6f2259df91757a42d0fa3000308d4ac0581dR2) [[6]](diffhunk://#diff-948733f55c432fc41cf7e647ae85ec51bb696afe7949c2800fa69a8e1308ce80R2) [[7]](diffhunk://#diff-ef661f6a7831f4bc1933cc732781449890c8d4e07b752a3b7de6e597e3af085bR3) [[8]](diffhunk://#diff-9fdcedde3a48b84d0641f8f07791496cc661c7dcfeda4dfbfb6b451507f96b0aR2) [[9]](diffhunk://#diff-cc045798c9b4cc7ba491396db3e0595991ee7bd5876acd67a560ff6ee6ce8ea0R2) [[10]](diffhunk://#diff-45505d31e4722a37d843bfb10268c945320a5b612ae566fcdf1493b24acaed9fR2)

Conflict resolution:

* Changed the `id` value for the `joomla` app from `3` to `12` to avoid a conflict with the newly added `n8n` app, which now uses `id: 3`. [[1]](diffhunk://#diff-aaaae9b5750960a36650888908fe51967c5ffc0d836c6ebcbe7e50f17f648647L3-R3) [[2]](diffhunk://#diff-948733f55c432fc41cf7e647ae85ec51bb696afe7949c2800fa69a8e1308ce80R2)