### PR TITLE
fix: privatebin may fail installing when running on high performatic environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 # 2025/09/04
 
 feat: add privatebin
+fix: add wait for php to be up and running
 
 # 2025/08/27
 

--- a/app/privatebin/manifest.yml
+++ b/app/privatebin/manifest.yml
@@ -21,6 +21,7 @@ installCmdSteps:
   - mv %installDirectory%/.htaccess.disabled %installDirectory%/.htaccess
   - cp -u %marketplaceCatalogItemAssetsDirPath%/conf.php %installDirectory%/cfg/conf.php
   - sed -i 's/goinfinite.local/%installHostname%/g' %installDirectory%/cfg/conf.php
+  - while ! supervisorctl status php-webserver | grep -iq RUNNING; do sleep 1; done
   - os runtime php update --hostname %installHostname% --version 8.3
 uninstallFileNames:
   - .htaccess


### PR DESCRIPTION
This pull request addresses a reliability issue with the PrivateBin installation process by ensuring that the PHP webserver is fully up and running before proceeding with further setup steps. This change helps prevent potential errors caused by attempting configuration updates before the server is ready.

Installation process reliability improvements:

* Added a step to the `installCmdSteps` in `app/privatebin/manifest.yml` that waits for the PHP webserver to be in the RUNNING state before continuing with installation commands.
* Updated the `CHANGELOG.md` to document the new wait-for-PHP step as a fix.