### PR TITLE
fix: update n8n manifest to use Node 24 LTS and pin version to 2.13.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 TODO.md
+.agents/
+.memory/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## v2
 
 ```
+# 2026/03/26
+
+fix: update n8n manifest to use Node 24 LTS and pin version to 2.13.4
+  - Node version: 20 → 24 (LTS)
+  - n8n version: @latest → @2.13.4 (pinned)
+  - Fixes compatibility issue with n8n@latest requiring Node >= 22.16
+
 # 2025/12/10
 
 feat: add umami

--- a/app/n8n/manifest.yml
+++ b/app/n8n/manifest.yml
@@ -16,10 +16,10 @@ installCmdSteps:
   - cp -u %marketplaceCatalogItemAssetsDirPath%/env.txt %installDirectory%/.env
   - sed -i 's|n8n_base_url|%installHostname%|g' %installDirectory%/.env
   - sed -i 's|n8n_user_folder|%installDirectory%|' %installDirectory%/.env
-  - cd %installDirectory% && mise x node@20 -- npm install n8n@latest
-  - os services create-installable --name node --port-bindings 5678/ws --version 20 --auto-create-mapping false --auto-start true --auto-restart true --startup-file %installDirectory%/node_modules/.bin/n8n --working-dir %installDirectory%
+  - cd %installDirectory% && mise x node@24 -- npm install n8n@2.13.4
+  - os services create-installable --name node --port-bindings 5678/ws --version 24 --auto-create-mapping false --auto-start true --auto-restart true --startup-file %installDirectory%/node_modules/.bin/n8n --working-dir %installDirectory%
 uninstallCmdSteps:
-  - cd %installDirectory% && mise x node@20 -- npm uninstall n8n
+  - cd %installDirectory% && mise x node@24 -- npm uninstall n8n
   - mv %installDirectory%/.n8n /app/.trash/.n8n-$(date +%s)
   - os services get | jq -r '.body.installedServices[]|select(.startCmd|contains("%installDirectory%/node_modules/.bin/n8n"))|.name' | xargs --no-run-if-empty os services delete --name
   - rm -fr /root/.npm/


### PR DESCRIPTION
## Summary

Fixes the n8n manifest to use Node 24 LTS and pins the n8n version to 2.13.4, resolving compatibility issues with the latest n8n package.

## Problem

The n8n manifest was using Node 20 and installing n8n@latest. The latest n8n version (2.13.4) requires Node.js >= 22.16, causing installation failures with the following error:

```
npm warn EBADENGINE Unsupported engine {
  package: 'n8n@2.13.4',
  required: { node: '>=22.16' },
  current: { node: 'v20.20.2', npm: '10.8.2' }
}
```

## Solution

Updated the manifest to:
- Use Node 24 LTS (major version only, allows patch updates)
- Pin n8n version to 2.13.4 (tested and working)
- Update all Node references consistently (install, uninstall, service creation)

## Changes

| File | Change |
|------|--------|
| `app/n8n/manifest.yml` | Node 20 → 24, n8n@latest → n8n@2.13.4 |
| `CHANGELOG.md` | Added entry for this fix |
| `.gitignore` | Added `.agents/` and `.memory/` (AI Framework directories) |

## Testing

- [x] Schema validation: PASS
- [x] Installation test: PASS (2m 45s)
- [x] Functionality test: PASS (HTTP 200, service running)
- [x] Uninstallation test: PASS (clean removal)
- [x] Container cleanup: PASS

Tested in Infinite OS v0.2.8 container with marketplace copied to `/infinite/marketplace`.

## QA Verification

Full test cycle completed by QA Tester persona:
- Installation: ✅ PASS
- Functionality: ✅ PASS  
- Uninstallation: ✅ PASS
- Cleanup: ✅ PASS

**Overall Verdict: PASS**

## Related

- Node LTS version discovered via `mise install node@lts` → v24.14.1
- n8n version discovered via `npm install n8n@latest` → v2.13.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated Node.js version requirement from v20 to v24 for n8n installation.
  * Pinned n8n dependency to version 2.13.4 instead of latest.

* **Chores**
  * Updated configuration file entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->