### PR TITLE
fix(umami): use CSPRNG for secrets and update pnpm to 10.33.0

### DIFF
--- a/app/umami/.context.md
+++ b/app/umami/.context.md
@@ -14,7 +14,7 @@ Umami application manifest — a self-hosted web analytics platform providing a 
 ## Constraints
 
 - Requires PostgreSQL 16 service.
-- Generates a random 32-character app secret during installation using SHA256 hash.
+- Generates a cryptographically secure random 32-character app secret during installation using OpenSSL CSPRNG.
 - Clones from GitHub repository during installation.
 
 ## Guidance

--- a/app/umami/assets/start_umami.sh
+++ b/app/umami/assets/start_umami.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cd install_dir && exec mise x pnpm@10.24 -- pnpm start
+cd install_dir && exec mise x pnpm@10.33 -- pnpm start

--- a/app/umami/manifest.yml
+++ b/app/umami/manifest.yml
@@ -15,7 +15,7 @@ installCmdSteps:
   - chown nobody:nogroup /app/start_umami.sh
   - cp -u %marketplaceCatalogItemAssetsDirPath%/env.txt %installDirectory%/.env
   - |
-    appSecret=$(date | sha256sum | head -c 32)
+    appSecret=$(openssl rand -hex 16)
     sed -i "s|secret|${appSecret}|" %installDirectory%/.env
     sed -i 's|db_name|umami_%installUuid%|' %installDirectory%/.env
     sed -i 's|db_user|umami_%installUuid%|' %installDirectory%/.env
@@ -41,8 +41,8 @@ installCmdSteps:
   - |
     cd %installDirectory%
     mise use -g node@lts && source /etc/profile
-    mise x pnpm@10.24 -- pnpm install
-    mise x pnpm@10.24 -- pnpm build
+    mise x pnpm@10.33 -- pnpm install
+    mise x pnpm@10.33 -- pnpm build
   - |
     os services create-custom \
       --name umami \


### PR DESCRIPTION
## Summary

Fixes #104 - replaces predictable secret generation with CSPRNG-based approach and updates pnpm to a working version.

## Changes

- **Security**: Changed `appSecret=$(date | sha256sum | head -c 32)` to `appSecret=$(openssl rand -hex 16)` for cryptographically secure secret generation
- **Dependencies**: Updated pnpm from non-existent `10.24` to `10.33.0` (latest working version)
- **Files modified**:
  - `app/umami/manifest.yml` (secret generation + pnpm version)
  - `app/umami/.context.md` (updated documentation)
  - `app/umami/assets/start_umami.sh` (pnpm version)

## Testing

- ✅ Container test with OS 0.2.8 completed successfully
- ✅ Installation completes without errors
- ✅ Generated secret is 32-character hexadecimal from openssl
- ✅ pnpm 10.33.0 installs and runs correctly
- ✅ Application responds on port 3000

## Security Impact

- **Before**: Secret derived from `date | sha256sum` - predictable and deterministic
- **After**: Secret from `openssl rand -hex 16` - cryptographically secure RNG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application secret generation configuration during installation
  * Upgraded pnpm package manager from version 10.24 to 10.33

<!-- end of auto-generated comment: release notes by coderabbit.ai -->