### PR TITLE
fix: improve pocketbase install script reliability

### DIFF
--- a/app/pocketbase/manifest.yml
+++ b/app/pocketbase/manifest.yml
@@ -17,10 +17,12 @@ dataFields:
     specificType: password
     isRequired: true
 installCmdSteps:
-  - curl -fsSL https://github.com/pocketbase/pocketbase/releases/download/v0.22.19/pocketbase_0.22.19_linux_amd64.zip -o %installTempDir%/pocketbase.zip
-  - curl -fsSL https://github.com/pocketbase/pocketbase/releases/download/v0.22.19/checksums.txt -o %installTempDir%/checksums.txt
-  - cd %installTempDir% && grep 'pocketbase_0.22.19_linux_amd64.zip$' checksums.txt | sha256sum -c -
-  - unzip -o %installTempDir%/pocketbase.zip -d %installDirectory%
+  - |
+    cd %installTempDir%
+    curl -fsSL https://github.com/pocketbase/pocketbase/releases/download/v0.22.19/pocketbase_0.22.19_linux_amd64.zip -o pocketbase_0.22.19_linux_amd64.zip
+    curl -fsSL https://github.com/pocketbase/pocketbase/releases/download/v0.22.19/checksums.txt -o checksums.txt
+    grep 'pocketbase_0.22.19_linux_amd64.zip' checksums.txt | sha256sum -c -
+    unzip -o %installTempDir%/pocketbase_0.22.19_linux_amd64.zip -d %installDirectory%
   - chmod +x %installDirectory%/pocketbase
   - os services create-custom --type application --name pocketbase-%installUuid% --port-bindings 8090/http --version 0.22.19 --auto-create-mapping true --auto-start true --auto-restart true --start-command "%installDirectory%/pocketbase serve" --mapping-hostname %installHostname% --mapping-path /
   - sleep 5

--- a/app/pocketbase/manifest.yml
+++ b/app/pocketbase/manifest.yml
@@ -21,7 +21,7 @@ installCmdSteps:
     cd %installTempDir%
     curl -fsSL https://github.com/pocketbase/pocketbase/releases/download/v0.22.19/pocketbase_0.22.19_linux_amd64.zip -o pocketbase_0.22.19_linux_amd64.zip
     curl -fsSL https://github.com/pocketbase/pocketbase/releases/download/v0.22.19/checksums.txt -o checksums.txt
-    grep 'pocketbase_0.22.19_linux_amd64.zip' checksums.txt | sha256sum -c -
+    awk '$NF=="pocketbase_0.22.19_linux_amd64.zip"' checksums.txt | sha256sum -c -
     unzip -o %installTempDir%/pocketbase_0.22.19_linux_amd64.zip -d %installDirectory%
   - chmod +x %installDirectory%/pocketbase
   - os services create-custom --type application --name pocketbase-%installUuid% --port-bindings 8090/http --version 0.22.19 --auto-create-mapping true --auto-start true --auto-restart true --start-command "%installDirectory%/pocketbase serve" --mapping-hostname %installHostname% --mapping-path /


### PR DESCRIPTION
## Summary
- Refactor curl commands in install script to use multi-line format for better reliability
- Fix checksum verification by using the correct filename in grep pattern

## Testing
- [x] Verified locally

## Notes
- Ready for merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored PocketBase installation command sequence and updated checksum verification to improve consistency in the installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->