### PR TITLE
fix: add services field to hermes-dashboard manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## v2
 
 ```
+# 2026/07/23
+
+fix: add services field to hermes-dashboard manifest
+  - Declares hermes-agent as a dependency service
+
 # 2026/06/08
 
 feat: add open-webui

--- a/app/hermes-dashboard/manifest.yaml
+++ b/app/hermes-dashboard/manifest.yaml
@@ -6,6 +6,8 @@ slugs:
   - hermes-dashboard
 type: app
 description: Hermes is a self-improving AI agent by Nous Research. It creates skills from experience, improves them during use, nudges itself to persist knowledge, searches its own past conversations, and builds a deepening model of who you are. Supports Telegram, Discord, Slack, WhatsApp, Signal, and more. Use any LLM via OpenRouter, OpenAI, Anthropic, Nous Portal, and others.
+services:
+  - hermes-agent
 installCmdSteps:
   - install_packages -qqy jq
   - |


### PR DESCRIPTION
Adds a `services` field declaring `hermes-agent` as a dependency service for the hermes-dashboard manifest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the dashboard configuration to recognize its required agent service.
* **Documentation**
  * Added a changelog entry describing the configuration fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->