### PR TITLE
fix: enable PHP IMAP extension during Mautic install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # CHANGELOG
 
 ## v2
-
 ```
+
+# 2026/07/24
+
+fix: enable PHP IMAP extension during Mautic install
+  - Adds runtime php update-module for imap to resolve composer dependency error
+
 # 2026/07/23
 
 fix: add services field to hermes-dashboard manifest

--- a/app/mautic/manifest.yml
+++ b/app/mautic/manifest.yml
@@ -39,6 +39,7 @@ dataFields:
 installCmdSteps:
   - os runtime php update --hostname %installHostname% --version 8.3
   - os runtime php update-setting --hostname %installHostname% --name memory_limit --value 512M --version 8.3
+  - os runtime php update-module --hostname %installHostname% --name imap --status true --version 8.3
   - curl -skL -o /app/composer-setup.php https://getcomposer.org/installer
   - php /app/composer-setup.php --install-dir=/usr/local/bin --filename=composer --quiet && rm -f /app/composer-setup.php
   - mise use node@lts && source /etc/profile


### PR DESCRIPTION
Mautic requires the PHP IMAP extension (`ext-imap`) as a dependency. Without it, `composer create-project` fails during installation.

This fix adds `os runtime php update-module --name imap --status true --version 8.3` to the install steps, enabling the extension before the composer setup runs.