### PR TITLE
fix: set utf8mb4 collation on Moodle database before install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 fix: enable PHP IMAP extension during Mautic install
   - Adds runtime php update-module for imap to resolve composer dependency error
 
+fix: set utf8mb4 collation on Moodle database before install
+  - Adds ALTER DATABASE to avoid charset mismatch during installation
+
 # 2026/07/23
 
 fix: add services field to hermes-dashboard manifest

--- a/app/moodle/manifest.yml
+++ b/app/moodle/manifest.yml
@@ -50,6 +50,7 @@ installCmdSteps:
   - os services update --name mariadb --status restart
   - os db create --db-type mysql --db-name moodle_%installUuid%
   - os db create-user --db-type mysql --db-name moodle_%installUuid% --username moodle_%installUuid% --password '%installRandomPassword%' --privileges all
+  - mariadb -u'moodle_%installUuid%' -p'%installRandomPassword%' moodle_%installUuid% -e "ALTER DATABASE moodle_%installUuid% CHARACTER SET = utf8mb4 COLLATE = utf8mb4_unicode_ci;"
   - su nobody --shell /bin/bash -c "php -d max_input_vars=5000 %installDirectory%/admin/cli/install.php --chmod=755 --wwwroot='https://%installHostname%%installUrlPath%' --dataroot='/app/%installHostname%-moodledata' --dbtype=mariadb --dbname=moodle_%installUuid% --dbuser=moodle_%installUuid% --dbpass='%installRandomPassword%' --dbport=3306 --fullname='%siteFullName%' --shortname='%siteShortName%' --adminuser='%adminUsername%' --adminpass='%adminPassword%' --adminemail='%adminEmail%' --non-interactive --agree-license"
   - echo -e '\n$CFG->routerconfigured = true;\n' >>%installDirectory%/config.php
   - os cron create --schedule '* * * * *' --comment 'MoodleCron' --command 'su nobody --shell /bin/bash -c "php %installDirectory%/admin/cli/cron.php"'


### PR DESCRIPTION
Moodle requires the database to use utf8mb4_unicode_ci collation. Without this, the installer fails due to a charset mismatch between the server default and what Moodle expects.

This fix adds an ALTER DATABASE statement after database creation to enforce the correct collation before the Moodle CLI installer runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Moodle installation issues caused by database character set mismatches.
  - Moodle databases now use `utf8mb4` encoding and collation during setup, improving compatibility and preventing installation failures.

- **Documentation**
  - Added a changelog entry describing the installation fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->