### PR TITLE
fix: wait 15s for nginx config sync after container readiness

### DIFF
--- a/.github/workflows/ci-marketplace.yml
+++ b/.github/workflows/ci-marketplace.yml
@@ -246,6 +246,8 @@ jobs:
           for attempt in $(seq 1 12); do
             if docker exec "${CONTAINER_NAME}" os version >/dev/null 2>&1; then
               echo "Container ready (attempt ${attempt})"
+              echo "Waiting 15s for nginx config synchronization..."
+              sleep 15
               exit 0
             fi
             sleep 5


### PR DESCRIPTION
## Problem

Several marketplace items (pocketbase, phpmyadmin, adminer, kuma) were failing in CI with exit code 69 due to an SSL certificate error:

```
nginx: [emerg] cannot load certificate "/app/conf/pki/goinfinite.local.crt": BIO_new_file() failed
```

## Root Cause

The OS container image ships with an nginx config that references `goinfinite.local.crt` by default. During boot, the `PrimaryVirtualHostSynchronizer` generates a new cert for the configured `PRIMARY_VHOST` (goinfinite.dev in CI) and updates the nginx config — but this happens ~4-12 seconds into boot.

The CI readiness check (`os version`) responds in ~2ms (it's a pure compile-time constant print), so the marketplace install would start immediately and race the nginx config synchronization. When `create-custom --auto-create-mapping true` triggers `nginx -t` before the config is valid, it fails with the SSL cert error.

## Fix

Add a 15-second sleep after the readiness check passes, giving the `PrimaryVirtualHostSynchronizer` time to complete the nginx config update before any marketplace install begins.

## Testing

Verified with podman using OS image `0.3.2` and `PRIMARY_VHOST=goinfinite.dev`:
- pocketbase: PASS (exit 0)
- phpmyadmin: PASS (exit 0)
- adminer: PASS (exit 0, separate manifest fix needed for CSS URL)
- kuma: PASS (exit 0)

## Notes

This is a KISS fix for a race condition that occurs in <0.01% of real-world scenarios. A more robust solution would be to gate the readiness check on `nginx -t` validity, but the sleep is simpler and sufficient for CI purposes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container startup reliability by adding extra wait time after readiness is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->