### PR TITLE
fix: update adminer CSS URL from master to main branch

### DIFF
--- a/app/adminer/manifest.yml
+++ b/app/adminer/manifest.yml
@@ -14,7 +14,7 @@ mappings:
     targetValue: php
 installCmdSteps:
   - wget "https://github.com/vrana/adminer/releases/download/v5.3.0/adminer-5.3.0.php" -O %installDirectory%/index.php
-  - wget "https://raw.githubusercontent.com/vrana/adminer/refs/heads/master/designs/pepa-linha/adminer.css" -O %installDirectory%/adminer.css
+  - wget "https://raw.githubusercontent.com/vrana/adminer/refs/heads/main/designs/pepa-linha/adminer.css" -O %installDirectory%/adminer.css
   - |
     if [[ -d /etc/postgresql/ ]]; then
       sed -i.backup 's/local.*all.*all.*peer/local all all md5/' /etc/postgresql/*/main/pg_hba.conf


### PR DESCRIPTION
## Problem

Adminer installation was failing in CI with exit code 69:

```
ERROR 404: Not Found
wget: unable to retrieve URL 'https://raw.githubusercontent.com/vrana/adminer/refs/heads/master/designs/pepa-linha/adminer.css'
```

## Root Cause

The upstream `vrana/adminer` repository renamed its default branch from `master` to `main`. The manifest was still referencing the old branch name, causing the CSS download to return 404.

## Fix

Updated the CSS download URL from `refs/heads/master` to `refs/heads/main`.

## Testing

Verified with podman using OS image `0.3.2` and `PRIMARY_VHOST=goinfinite.dev`:
- adminer: PASS (exit 0)
- CSS file downloaded successfully (9001 bytes, valid CSS content)
- HTTP 200 at `goinfinite.dev/` and `goinfinite.dev/adminer.css`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Adminer installation process to download the latest CSS from GitHub’s `main` branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->