### PR TITLE
fix: set composer minimum-stability to dev for OpenMage dependencies

### DIFF
--- a/app/openmage/manifest.json
+++ b/app/openmage/manifest.json
@@ -789,6 +789,8 @@
     "os runtime php update -n '%installHostname%' -v 8.2",
     "os vhost mapping create -n '%installHostname%' -p '%installUrlPath%' -t service -v php >/dev/null 2>&1 || true",
     "composer init --name=openmage/openmage -d %installDirectory% -n -q",
+    "composer config minimum-stability dev -f %installDirectory%/composer.json -q",
+    "composer config prefer-stable true -f %installDirectory%/composer.json -q",
     "composer config --json extra.enable-patching true -f %installDirectory%/composer.json -q",
     "composer config extra.magento-core-package-type magento-source -f %installDirectory%/composer.json -q",
     "composer config extra.magento-root-dir %installDirectory% -f %installDirectory%/composer.json -q",


### PR DESCRIPTION
## Problem

OpenMage installation was failing in CI at the composer require step:

```
composer require "openmage/magento-lts":"^20.0.0" -d %installDirectory% -q
```

Error:
```
Your requirements could not be resolved to an installable set of packages.
openmage/magento-lts v20.18.0 requires flowjs/flowjs dev-master -> found flowjs/flowjs[dev-master] but it does not match your minimum-stability.
```

## Root Cause

The manifest runs `composer init` to create a fresh composer.json, which defaults to `minimum-stability: stable`. However, `openmage/magento-lts` depends on `flowjs/flowjs dev-master`, which is a dev-level package. Composer rejects it unless `minimum-stability` is set to `dev`.

## Fix

Added `composer config minimum-stability dev` after `composer init` and before the `composer require` steps.

## Testing

Verified with podman using OS image `0.3.2` and `PRIMARY_VHOST=goinfinite.dev`:
- openmage: PASS (exit 0, duration 129s)
- `openmage/magento-lts v20.18.0` installed successfully
- HTTP 200 at storefront, admin route accessible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenMage project installation now supports development-stability Composer packages while preferring stable releases when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->