### PR TITLE
fix: add --add-host flag for openmage CI test only

### DIFF
--- a/.github/workflows/ci-marketplace.yml
+++ b/.github/workflows/ci-marketplace.yml
@@ -232,10 +232,15 @@ jobs:
         run: |
           container_name="${ITEM_SLUG}-ci-${{ github.run_id }}"
           echo "container_name=${container_name}" >> "$GITHUB_OUTPUT"
+          add_host_flag=""
+          if [ "${ITEM_SLUG}" = "openmage" ]; then
+            add_host_flag="--add-host ${CI_DOMAIN}:127.0.0.1"
+          fi
           docker run -d --rm \
             --name "${container_name}" \
             --cpus=2 \
             --memory=4G \
+            ${add_host_flag} \
             --env "PRIMARY_VHOST=${CI_DOMAIN}" \
             --env "LOG_LEVEL=debug" \
             docker.io/goinfinite/os:${OS_TAG}


### PR DESCRIPTION
## Problem

OpenMage's `install.php` makes an HTTP self-check to the install URL during installation. It expects the hostname to resolve back to the container's nginx and return `MAGENTO`. Without `--add-host`, the domain resolves to a public IP and the self-check fails.

## Root Cause

The install script validates that the provided URL is accessible by making an HTTP request from inside the container. In CI, `goinfinite.dev` resolves to a public IP (216.238.102.32), so the request goes to the internet instead of the container's nginx, returning 404 instead of `MAGENTO`.

## Fix

Add `--add-host goinfinite.dev:127.0.0.1` to the `docker run` command, but ONLY when testing openmage. Other items don't need this and shouldn't be affected.

The implementation uses a conditional bash variable:
```bash
add_host_flag=""
if [ "${ITEM_SLUG}" = "openmage" ]; then
  add_host_flag="--add-host ${CI_DOMAIN}:127.0.0.1"
fi
```

## Testing

Verified with podman using OS image `0.3.2` and `PRIMARY_VHOST=goinfinite.dev`:
- openmage with `--add-host`: PASS (exit 0)
- `getent hosts goinfinite.dev` returns `127.0.0.1`
- install.php self-check succeeds, HTTP 200 at storefront

## Dependencies

This PR requires #120 (openmage composer minimum-stability fix) to be merged first, otherwise the install will fail at the composer step before reaching the self-check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved marketplace test container networking for the OpenMage item, enabling reliable access to the local CI environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->